### PR TITLE
Feature/#66 activate account panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import { AdminPanel } from "./components/AdminPanel/AdminPanel";
 import { errorNotif } from "./utils/notifications/errorNotif";
 import { ToastContainer } from "react-toastify";
 import { MainHeader } from "./components/MainHeader";
-
+import {ActivateAccountForm} from './components/ActivateAccountForm/ActivateAccountForm';
 
 export const App = () => {
   const { user } = useContext(AuthContext);
@@ -42,6 +42,9 @@ export const App = () => {
         pauseOnHover
         theme='dark'
       />
+      <Routes>
+        <Route path="activate/:userId/:activationToken" element={<ActivateAccountForm />} />
+      </Routes>
       <ProtectedRoute isAllowed={!user}>
         <Routes>
           <Route path="*" element={<LoginForm />} />

--- a/src/Providers/AuthProvider.tsx
+++ b/src/Providers/AuthProvider.tsx
@@ -7,6 +7,7 @@ export const AuthContext = React.createContext<AuthContextObj>({
   user: null,
   signIn: () => {},
   signOut: () => {},
+  activateAccount: () => {},
 });
 
 export const AuthProvider = ({children}: {children: React.ReactNode}) => {
@@ -63,6 +64,30 @@ export const AuthProvider = ({children}: {children: React.ReactNode}) => {
     }
   }
 
+  const activateAccount = async (userId: string, activationToken: string, password: string) => {
+    try {
+      const res = await fetch(`/auth/activate/${userId}/${activationToken}`, {
+        method: 'PATCH',
+        mode: 'cors',
+        headers: {
+          "Access-Control-Allow-Origin":"true",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          newPassword: password,
+        }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        toast.success(data.message);
+      } else {
+        toast.error(data.message);
+      }
+    } catch (e) {
+      toast.error('Coś poszło nie tak, spróbuj później!');
+    }
+  }
+
   const signOut = async () => {
     setUser(null);
     try {
@@ -86,7 +111,7 @@ export const AuthProvider = ({children}: {children: React.ReactNode}) => {
   }
 
   return (
-    <AuthContext.Provider value={{user, signIn, signOut}}>
+    <AuthContext.Provider value={{user, signIn, signOut, activateAccount}}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/components/ActivateAccountForm/ActivateAccountForm.tsx
+++ b/src/components/ActivateAccountForm/ActivateAccountForm.tsx
@@ -1,0 +1,59 @@
+import React, {useContext, useState} from "react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import {AuthContext} from "../../Providers/AuthProvider";
+
+type FormInputs = {
+  password: string;
+  confirmPassword: string;
+};
+
+export const ActivateAccountForm = () => {
+  const {signIn} = useContext(AuthContext);
+  const { register, handleSubmit, formState: { errors } } = useForm<FormInputs>();
+  const [missmatchPassword, setMissmatchPassword] = useState<boolean>(false);
+
+  const onSubmit: SubmitHandler<FormInputs> = async ({password, confirmPassword}) => {
+    try {
+      if(password !== confirmPassword) {
+        setMissmatchPassword(true);
+        return;
+      }
+      console.log(password);
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  return (
+    <>
+      <div className="loginContainer">
+        <div className="loginContainer__layoutLoginForm">
+          <img className="loginContainer__logo" src="/assets/images/megak_logo.webp" alt="MegaK logo" />
+          <h2>Ustaw hasło i aktywuj konto</h2>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <input {...register("password", { required: true, maxLength: 255, minLength: 6 })} type="password" placeholder="Hasło" />
+            {errors.password?.type === "required" && "To pole jest wymagane"}
+            {errors.password?.type === "maxLength" && "Hasło może się składać z maksymalnie 255 znaków"}
+            {errors.password?.type === "minLength" && "Hasło musi się składać z co najmniej 6 znaków"}
+            <input
+              {...register("confirmPassword", { required: true, maxLength: 255, minLength: 6 })}
+              type="password"
+              placeholder="Potwierdź hasło"
+            />
+            {errors.confirmPassword?.type === "required" && "To pole jest wymagane"}
+            {errors.confirmPassword?.type === "maxLength" && "Hasło może się składać z maksymalnie 255 znaków"}
+            {errors.confirmPassword?.type === "minLength" && "Hasło musi się składać z co najmniej 6 znaków"}
+            {missmatchPassword && 'Hasła powinny być jednakowe!'}
+            <div className="lastLine">
+              <div></div>
+              <button className="loginButton"
+                      type="submit">
+                Zatwierdź
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/ActivateAccountForm/ActivateAccountForm.tsx
+++ b/src/components/ActivateAccountForm/ActivateAccountForm.tsx
@@ -1,6 +1,7 @@
 import React, {useContext, useState} from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import {AuthContext} from "../../Providers/AuthProvider";
+import {useNavigate, useParams} from "react-router-dom";
 
 type FormInputs = {
   password: string;
@@ -8,17 +9,24 @@ type FormInputs = {
 };
 
 export const ActivateAccountForm = () => {
-  const {signIn} = useContext(AuthContext);
+  const {activateAccount} = useContext(AuthContext);
   const { register, handleSubmit, formState: { errors } } = useForm<FormInputs>();
-  const [missmatchPassword, setMissmatchPassword] = useState<boolean>(false);
+  const [mismatchPassword, setMismatchPassword] = useState<boolean>(false);
+  const {userId, activationToken} = useParams<string>();
+  const navigate = useNavigate();
 
   const onSubmit: SubmitHandler<FormInputs> = async ({password, confirmPassword}) => {
     try {
       if(password !== confirmPassword) {
-        setMissmatchPassword(true);
+        setMismatchPassword(true);
         return;
       }
-      console.log(password);
+      if(!userId || !activationToken) {
+        navigate('/');
+      } else {
+        await activateAccount(userId, activationToken, password);
+        navigate('/');
+      }
     } catch (e) {
       console.log(e);
     }
@@ -43,7 +51,7 @@ export const ActivateAccountForm = () => {
             {errors.confirmPassword?.type === "required" && "To pole jest wymagane"}
             {errors.confirmPassword?.type === "maxLength" && "Hasło może się składać z maksymalnie 255 znaków"}
             {errors.confirmPassword?.type === "minLength" && "Hasło musi się składać z co najmniej 6 znaków"}
-            {missmatchPassword && 'Hasła powinny być jednakowe!'}
+            {mismatchPassword && 'Hasła powinny być jednakowe!'}
             <div className="lastLine">
               <div></div>
               <button className="loginButton"

--- a/src/types/interfaces/Auth.ts
+++ b/src/types/interfaces/Auth.ts
@@ -10,6 +10,7 @@ export interface AuthContextObj {
   user: AuthUser | null,
   signIn: ({login, password}: LoginData) => void,
   signOut: () => void,
+  activateAccount: (userId: string, activationToken: string, password: string) => void,
 }
 
 export interface ProtectedRouteInterface {


### PR DESCRIPTION
Added activate account panel for setting new password and activate account. Form is validated by input length. The password and password confirmation must match to each other. The form is using newly added activateAccount method which takes the userId and activationToken from the path and sent it back to the server with new password in body. The module uses toastify for messages and errors display